### PR TITLE
Support uploading models to HuggingFace Hub

### DIFF
--- a/docs/source/api/kithara.model_api.rst
+++ b/docs/source/api/kithara.model_api.rst
@@ -73,8 +73,10 @@ save_in_hf_format
    - Model weights file (model.safetensors for models smaller than DEFAULT_MAX_SHARD_SIZE, model-x-of-x.safetensors for larger models)
    - Safe tensors index file (model.safetensors.index.json)
 
-   :param output_dir: Directory path where the model should be saved. Can be local or Google cloud storage path.
-                   Will be created if it doesn't exist.
+   :param output_dir: Directory path where the model should be saved. Can be a local folder (e.g. "foldername/"), 
+                HuggingFaceHub repo prefixed with "hf://" (e.g. "hf://your_hf_id/repo_name") or a 
+                Google cloud storage path prefixed with "gs://" (e.g. "gs://your_bucket/folder_name), 
+                and will be created if it doesn't exist. 
    :param dtype: Data type for saved weights. Defaults to "auto" which saves the model in its current precision type. (default: "auto")
    :param parallel_threads: Number of parallel threads to use for saving (default: 8).
                         Note: Local system must have at least parallel_threads * DEFAULT_MAX_SHARD_SIZE free disk space,
@@ -155,8 +157,10 @@ save_in_hf_format
 
    Save the model in HuggingFace format, including configuration and weights files.
 
-   :param output_dir: Directory path where the model should be saved. Can be local or Google cloud storage path.
-                   Will be created if it doesn't exist.
+   :param output_dir: Directory path where the model should be saved. Can be a local folder (e.g. "foldername/"), 
+                HuggingFaceHub repo prefixed with "hf://" (e.g. "hf://your_hf_id/repo_name") or a 
+                Google cloud storage path prefixed with "gs://" (e.g. "gs://your_bucket/folder_name), 
+                and will be created if it doesn't exist. 
    :param dtype: Data type for saved weights. Defaults to "auto" which saves the model in its current precision type.
    :param only_save_adapters: If True, only adapter weights will be saved. If False, both base model weights and adapter weights will be saved. (default: False)
    :param save_adapters_separately: If False, adapter weights will be merged with base model. If True, adapter weights will be saved separately in HuggingFace's peft format. (default: False)

--- a/docs/source/finetuning_guide.rst
+++ b/docs/source/finetuning_guide.rst
@@ -40,7 +40,7 @@ Quick tips:
 - Always start model handles with ``hf://`` when loading from HuggingFace - so we know you are not loading from local directory 😀
 - The default precision ``mixed_bfloat16`` is your friend - it's memory-friendly! It loads model weights in full precision and casts activations to bfloat16.
 - Check out our :doc:`model garden <models>` for supported architectures
-- Want to save your model? Simply do ``model.save_in_hf_format(local_dir_or_gs_bucket_or_hf_hub)``
+- Want to save your model? Simply do ``model.save_in_hf_format(destination)`` to either save it locally, to GCS, or to HuggingFace.
 - Check out :doc:`Model API <api/kithara.model_api>` documentation
 
 2. Prepare Your Data

--- a/docs/source/finetuning_guide.rst
+++ b/docs/source/finetuning_guide.rst
@@ -40,7 +40,7 @@ Quick tips:
 - Always start model handles with ``hf://`` when loading from HuggingFace - so we know you are not loading from local directory 😀
 - The default precision ``mixed_bfloat16`` is your friend - it's memory-friendly! It loads model weights in full precision and casts activations to bfloat16.
 - Check out our :doc:`model garden <models>` for supported architectures
-- Want to save your model? Simply do ``model.save_in_hf_format(local_dir_or_gs_bucket)``
+- Want to save your model? Simply do ``model.save_in_hf_format(local_dir_or_gs_bucket_or_hf_hub)``
 - Check out :doc:`Model API <api/kithara.model_api>` documentation
 
 2. Prepare Your Data

--- a/docs/source/lora.rst
+++ b/docs/source/lora.rst
@@ -35,7 +35,7 @@ You have three options for saving models trained with LoRA:
 Since the base model is left unchanged, you can save just the LoRA Adapters::
 
     model.save_in_hf_format(
-        local_dir_or_gs_bucket_or_hf_hub,
+        destination,
         only_save_adapters=True
     )
 
@@ -44,7 +44,7 @@ Since the base model is left unchanged, you can save just the LoRA Adapters::
 In case you want to save the base model as well. ::
 
     model.save_in_hf_format(
-        local_dir_or_gs_bucket_or_hf_hub,
+        destination,
         only_save_adapters=False,
         save_adapters_separately=True
     )
@@ -54,7 +54,7 @@ In case you want to save the base model as well. ::
 Creates a single model combining base weights and adaptations::
 
     model.save_in_hf_format(
-        local_dir_or_gs_bucket_or_hf_hub,
+        destination,
         save_adapters_separately=False
     )
 

--- a/docs/source/lora.rst
+++ b/docs/source/lora.rst
@@ -35,7 +35,7 @@ You have three options for saving models trained with LoRA:
 Since the base model is left unchanged, you can save just the LoRA Adapters::
 
     model.save_in_hf_format(
-        local_dir_or_gs_bucket,
+        local_dir_or_gs_bucket_or_hf_hub,
         only_save_adapters=True
     )
 
@@ -44,7 +44,7 @@ Since the base model is left unchanged, you can save just the LoRA Adapters::
 In case you want to save the base model as well. ::
 
     model.save_in_hf_format(
-        local_dir_or_gs_bucket,
+        local_dir_or_gs_bucket_or_hf_hub,
         only_save_adapters=False,
         save_adapters_separately=True
     )
@@ -54,7 +54,7 @@ In case you want to save the base model as well. ::
 Creates a single model combining base weights and adaptations::
 
     model.save_in_hf_format(
-        local_dir_or_gs_bucket,
+        local_dir_or_gs_bucket_or_hf_hub,
         save_adapters_separately=False
     )
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -14,6 +14,6 @@ We support all safetensor formatted models on `HuggingFace Hub <https://huggingf
    * - Gemma 2
      - 2B, 9B, 27B
      - google/gemma-2-2b
-   * - Llama 3
+   * - Llama 3.1
      - 8B, 27B, 405B
      - meta-llama/Llama-3.1-8B

--- a/docs/source/pretraining.rst
+++ b/docs/source/pretraining.rst
@@ -168,6 +168,8 @@ Step 7: Save Model
 Save the model in the HuggingFace format::
 
     model.save_in_hf_format("gs://my-bucket/models")
+    # Or, if you prefer saving to HuggingFace Hub 
+    # model.save_in_hf_format("hf://my-hf-id/repo-name")
 
 
 Notes

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,7 +10,10 @@ The script can also be found on `Github <https://github.com/AI-Hypercomputer/kit
 
 Setup
 -----
-Import required packages::
+Log into HuggingFace and import required packages::
+
+    from huggingface_hub import login
+    login(token="your_hf_token", add_to_git_credential=False)
 
     import os
     os.environ["KERAS_BACKEND"] = "jax"
@@ -23,6 +26,9 @@ Import required packages::
         SFTDataset,
     )
 
+.. tip::
+    New to HuggingFace? First create an access token, `apply access <https://huggingface.co/google/gemma-2-2b>`_ to the Gemma2 HuggingFace model which will be used in this example.
+
 Quick Usage
 ----------
 
@@ -33,9 +39,6 @@ Quick Usage
         precision="mixed_bfloat16",
         lora_rank=4,
     )
-
-.. tip::
-    New to HuggingFace? First create an access token, `apply access <https://huggingface.co/google/gemma-2-2b>`_ to the HuggingFace model, and set the ``HF_TOKEN`` environment variable.
     
 2. Prepare Dataset::
 

--- a/docs/source/sft.rst
+++ b/docs/source/sft.rst
@@ -172,7 +172,7 @@ Step 6: Save Model
 Save the model in the Hugging Face format::
 
     model.save_in_hf_format(
-        "model_output/", # You can also save the model to a Google Cloud Storage bucket
+        "model_output/", # You can also save the model to Google Cloud Storage, or directly to HuggingFace Hub
         only_save_adapters=True, # You can also save the base model, or merge the base model with the adapters
         save_adapters_separately=True
     )

--- a/kithara/model/hf_compatibility/to_huggingface.py
+++ b/kithara/model/hf_compatibility/to_huggingface.py
@@ -156,7 +156,7 @@ def create_huggingface_hub_repo_if_not_exist(repo_id, repo_type):
         print(f"\n Created new HuggingFace Hub {repo_type} repo: {repo_id}.")
 
 
-def copy_local_file_to_huggingface_hub(local_path, file_name, repo_id, repo_type):
+def upload_file_to_huggingface_hub(local_path, file_name, repo_id, repo_type):
     api = HfApi()
     api.upload_file(
         path_or_fileobj=local_path,
@@ -208,7 +208,7 @@ def save_index_file(index: dict, local_dir: str, output_dir: str, file_name: str
                 remove_local_file_after_upload=True,
             )
         elif output_dir.startswith("hf://"):
-            copy_local_file_to_huggingface_hub(
+            upload_file_to_huggingface_hub(
                 local_path=local_path,
                 file_name=file_name,
                 repo_id=output_dir.lstrip("hf://"),
@@ -229,7 +229,7 @@ def save_config_file(config, local_dir: str, output_dir: str, file_name: str):
                 remove_local_file_after_upload=True,
             )
         elif output_dir.startswith("hf://"):
-            copy_local_file_to_huggingface_hub(
+            upload_file_to_huggingface_hub(
                 local_path=local_path,
                 file_name=file_name,
                 repo_id=output_dir.lstrip("hf://"),
@@ -249,7 +249,7 @@ def save_peft_config_file(config: PeftConfig, local_dir: str, output_dir: str):
                 remove_local_file_after_upload=True,
             )
         elif output_dir.startswith("hf://"):
-            copy_local_file_to_huggingface_hub(
+            upload_file_to_huggingface_hub(
                 local_path=local_path,
                 file_name=SAFE_TENSORS_PEFT_CONFIG_FILE,
                 repo_id=output_dir.lstrip("hf://"),
@@ -269,7 +269,7 @@ def save_safetensor_file(state_dict, local_dir, output_dir, file_name):
                 local_path, cloud_path, remove_local_file_after_upload=True
             )
         elif output_dir.startswith("hf://"):
-            copy_local_file_to_huggingface_hub(
+            upload_file_to_huggingface_hub(
                 local_path=local_path,
                 file_name=file_name,
                 repo_id=output_dir.lstrip("hf://"),

--- a/kithara/model/kerashub/keras_hub_model.py
+++ b/kithara/model/kerashub/keras_hub_model.py
@@ -151,8 +151,10 @@ class KerasHubModel(Model):
 
         Args:
             output_dir (str): Directory path where the model should be saved.
-                Directory could be local or a Google cloud storage path, and will be created if
-                it doesn't exist.
+                Directory could be a local folder (e.g. "foldername/"), 
+                HuggingFaceHub repo (e.g. "hf://your_hf_id/repo_name") or a 
+                Google cloud storage path (e.g. "gs://your_bucket/folder_name), 
+                and will be created if it doesn't exist. 
             dtype (str, optional): Data type for saved weights. Defaults to "auto".
             only_save_adapters (bool): If set to True, only adapter weights will be saved. If
                 set to False, both base model weights and adapter weights will be saved. Default

--- a/kithara/model/maxtext/maxtext_model.py
+++ b/kithara/model/maxtext/maxtext_model.py
@@ -211,8 +211,10 @@ class MaxTextModel(Model, MaxTextConversionMixin):
 
         Args:
             output_dir (str): Directory path where the model should be saved.
-                Directory could be local or a Google cloud storage path, and
-                will be created if it doesn't exist.
+                Directory could be a local folder (e.g. "foldername/"), 
+                HuggingFaceHub repo (e.g. "hf://your_hf_id/repo_name") or a 
+                Google cloud storage path (e.g. "gs://your_bucket/folder_name), 
+                and will be created if it doesn't exist. 
             dtype (str, optional): Data type for saved weights. Defaults to "auto".
             parallel_threads (int, optional): Number of parallel threads to use for saving.
                 Defaults to 8. Make sure the local system has at least

--- a/tests/model/maxtext/ckpt_compatibility/test_saving_models.py
+++ b/tests/model/maxtext/ckpt_compatibility/test_saving_models.py
@@ -150,5 +150,31 @@ class TestSavingModels(unittest.TestCase):
             top1_token_tol=0.01
         )
 
+    @unittest.skipIf(int(os.getenv('RUN_SKIPPED_TESTS', 0)) != 1, "Manual Test")
+    def test_saving_to_huggingface_hub(self):
+        """Test saving a model directly to HuggingFace Hub."""
+        # Create Model
+        model = MaxTextModel.from_random(
+            "gemma2-2b",
+            seq_len=self.MAX_TARGET_LENGTH,
+            per_device_batch_size=1,
+            scan_layers=True,
+            precision="mixed_bfloat16",
+        )
+
+        # Save model
+        repo_id = "hf://wxxxxd/gemma-2-2b-test"
+        model.save_in_hf_format(repo_id, parallel_threads=1)
+    
+        # Load model
+        model = MaxTextModel.from_preset(
+            repo_id,
+            seq_len=self.MAX_TARGET_LENGTH,
+            per_device_batch_size=1,
+            scan_layers=True,
+            precision="mixed_bfloat16",
+        )
+        
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
1. Added support for uploading models directly to HuggingFace Hub. This means the user now has three options for saving a model: to local directory, to GCS, or to HuggingFace Hub. 
2. Added unit tests
3. Updated docs.